### PR TITLE
Sanitize zsh history file before upload

### DIFF
--- a/lib/big_brother/reader.rb
+++ b/lib/big_brother/reader.rb
@@ -1,7 +1,8 @@
 class BigBrother::Reader
   def self.lines_from_history_file(filename)
     File.readlines(filename).map(&:strip).reject(&:empty?)
-    .map { |line| line.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '') }
+    .map { |line| line.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
+    .gsub(/\A: \d+:0;/, '') }
   end
 
   def self.move_history_file


### PR DESCRIPTION
So the `.zhistory` file prepends some sort of hash to each shell command, like so:
``` bash
: 1426804444:0;clear
: 1426804522:0;cat ~/.zhistory | pbcopy
```
This PR is just to remove everything from the start of the line up to the semicolon, thus leaving the command.