### PR TITLE
Append old history rather than overwrite it

### DIFF
--- a/lib/big_brother/reader.rb
+++ b/lib/big_brother/reader.rb
@@ -9,7 +9,9 @@ class BigBrother::Reader
     hist_file     = BigBrother::Settings.get("history_file")
     old_hist_file = BigBrother::Settings.get("history_file") + ".old"
     history = File.read hist_file
-    File.write old_hist_file, history
+    File.open(old_hist_file, "a") { |f|
+      f.puts history
+    }
     File.open(hist_file, "w") {}
   end
 end


### PR DESCRIPTION
Instead of writing over the `history.old` file on every push to `big_bro`, it would be better to append to it so as to keep all history over time.